### PR TITLE
Enable live VOO data and report final return

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,22 +9,33 @@ the monthly contribution increases by `20%` (`$120`). When the price rises by
 The repository includes:
 
 - `data/voo_prices.csv` – sample monthly price data used for testing.
-- `src/pad_strategy.py` – implementation of the back‑test logic.
+- `src/pad_strategy.py` – implementation of the back‑test logic. The script can
+  download historical VOO prices automatically using `yfinance`.
 - `tests/` – unit tests validating the strategy.
 
 ## Running the back‑test
 
+
+Running without arguments downloads the full history of VOO prices:
+
 ```bash
-python src/pad_strategy.py data/voo_prices.csv
+python src/pad_strategy.py
 ```
 
-This prints the month‑by‑month history and the final portfolio value.
+You can also supply your own CSV file:
+
+```bash
+python src/pad_strategy.py --csv data/voo_prices.csv
+```
+
+This prints the month‑by‑month history, the final portfolio value and the final
+total return.
 
 ## Running the tests
 
 The project uses `pytest` for testing. Install dependencies and run tests with:
 
 ```bash
-pip install pandas pytest
+pip install pandas yfinance pytest
 pytest
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pandas
+yfinance
 pytest

--- a/tests/test_pad_strategy.py
+++ b/tests/test_pad_strategy.py
@@ -67,3 +67,13 @@ def test_portfolio_value_consistency():
         abs(result.loc[i, "PortfolioValue"] - result.loc[i, "TotalShares"] * result.loc[i, "Price"]) < 1e-8
         for i in range(len(result))
     )
+
+
+def test_final_total_return_column():
+    df = sample_price_df()
+    result = backtest_pad(df)
+
+    total_deposit = result["TotalDeposit"].iloc[-1]
+    expected_return = result["PortfolioValue"].iloc[-1] / total_deposit - 1
+    assert "FinalTotalReturn" in result.columns
+    assert abs(result["FinalTotalReturn"].iloc[-1] - expected_return) < 1e-8


### PR DESCRIPTION
## Summary
- fetch historical VOO prices using yfinance
- track cumulative deposits and compute the final total return
- expose a CLI that can use either downloaded data or a CSV file
- document the new behaviour in the README
- update tests for the new column
- add yfinance to requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*