### PR TITLE
Adjust PAD strategy and output

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ The repository includes:
 
 - `data/voo_prices.csv` – sample monthly price data used for testing.
 - `src/pad_strategy.py` – implementation of the back‑test logic. The script can
-  download historical VOO prices automatically using `yfinance`.
+  download historical VOO prices automatically using `yfinance`. Prices are
+  aggregated to month end so the PAD logic runs on monthly data.
 - `tests/` – unit tests validating the strategy.
 
 ## Running the back‑test
@@ -28,8 +29,8 @@ You can also supply your own CSV file:
 python src/pad_strategy.py --csv data/voo_prices.csv
 ```
 
-This prints the month‑by‑month history, the final portfolio value and the final
-total return.
+This prints the month‑by‑month history. At the end it prints the final
+portfolio value, the net profit and the final total return as a percentage.
 
 ## Running the tests
 

--- a/tests/test_pad_strategy.py
+++ b/tests/test_pad_strategy.py
@@ -69,11 +69,21 @@ def test_portfolio_value_consistency():
     )
 
 
-def test_final_total_return_column():
+def test_net_profit_and_return():
     df = sample_price_df()
     result = backtest_pad(df)
 
     total_deposit = result["TotalDeposit"].iloc[-1]
-    expected_return = result["PortfolioValue"].iloc[-1] / total_deposit - 1
-    assert "FinalTotalReturn" in result.columns
-    assert abs(result["FinalTotalReturn"].iloc[-1] - expected_return) < 1e-8
+    final_value = result["PortfolioValue"].iloc[-1]
+    expected_return = final_value / total_deposit - 1
+    expected_profit = final_value - total_deposit
+
+    # Net profit column should match portfolio value minus total deposit
+    assert "NetProfit" in result.columns
+    assert abs(result["NetProfit"].iloc[-1] - expected_profit) < 1e-8
+
+    # There should no longer be a FinalTotalReturn column
+    assert "FinalTotalReturn" not in result.columns
+
+    # Calculated final return should be correct
+    assert abs(expected_return - (final_value / total_deposit - 1)) < 1e-8


### PR DESCRIPTION
## Summary
- fetch VOO prices monthly instead of daily
- adjust PAD logic to accept percentage threshold and track net profit
- print final return as a percentage and show net profit
- update tests for new columns and behaviour
- document monthly data usage and new outputs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install pandas yfinance pytest` *(fails: Could not find a version that satisfies the requirement pandas)*