### PR TITLE
Add ticker support and logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # AlgoTrader2
 
 This project demonstrates a simple back‑test of a **Percentage Allocation DCA (PAD)**
-strategy applied to the ETF VOO. Each month an investor contributes `$100` by
-default. If the VOO price drops by `20%` or more relative to the previous month,
-the monthly contribution increases by `20%` (`$120`). When the price rises by
+strategy applied to stocks or ETFs. Each month an investor contributes `$100` by
+default. If the price drops by `20%` or more relative to the previous month, the
+monthly contribution increases by `20%` (`$120`). When the price rises by
 `20%` or more, the contribution is reduced by `20%` (`$80`).
 
 The repository includes:
 
 - `data/voo_prices.csv` – sample monthly price data used for testing.
 - `src/pad_strategy.py` – implementation of the back‑test logic. The script can
-  download historical VOO prices automatically using `yfinance`. Prices are
+  download historical prices automatically using `yfinance`. Prices are
   aggregated to month end so the PAD logic runs on monthly data.
 - `tests/` – unit tests validating the strategy.
 
@@ -23,13 +23,17 @@ Running without arguments downloads the full history of VOO prices:
 python src/pad_strategy.py
 ```
 
-You can also supply your own CSV file:
+You can also supply your own CSV file or specify a different ticker:
 
 ```bash
 python src/pad_strategy.py --csv data/voo_prices.csv
+
+python src/pad_strategy.py --ticker AAPL
 ```
 
 The threshold for adjusting deposits can be specified with `--threshold` (default `20`).
+Results can be logged to a directory using `--log <dir>`, which writes a file
+named like `TICKER_YYYYMMDD.txt` containing the final summary and history.
 
 This prints the month‑by‑month history. At the end it prints the final
 portfolio value, the total amount deposited, the net profit and the final


### PR DESCRIPTION
## Summary
- support multiple tickers with `--ticker`
- add optional logging with `--log`
- show start date, end date and duration in summary output
- document new CLI options in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*