### PR TITLE
Fix lumpsum price column

### DIFF
--- a/src/pad_strategy.py
+++ b/src/pad_strategy.py
@@ -133,6 +133,17 @@ def run_backtest(
     )
 
 
+def calculate_lump_sum(result_df: pd.DataFrame) -> tuple[float, float]:
+    """Return lump sum shares and profit using the backtest result."""
+
+    total_deposit = result_df.iloc[-1]["TotalDeposit"]
+    first_price = result_df.iloc[0]["Price"]
+    last_price = result_df.iloc[-1]["Price"]
+    shares = total_deposit / first_price
+    profit = shares * last_price - total_deposit
+    return shares, profit
+
+
 if __name__ == "__main__":
     import argparse
 
@@ -184,8 +195,9 @@ if __name__ == "__main__":
     final_return = (final_value / total_deposit - 1) * 100
     net_profit = final_value - total_deposit
 
-    lumpsum_shares = total_deposit / df.iloc[0]["Close"]
-    lumpsum_value = lumpsum_shares * df.iloc[-1]["Close"]
+    # Use Price column from the backtest result for lump sum calculations
+    lumpsum_shares = total_deposit / df.iloc[0]["Price"]
+    lumpsum_value = lumpsum_shares * df.iloc[-1]["Price"]
     lumpsum_profit = lumpsum_value - total_deposit
     profit_diff = net_profit - lumpsum_profit
     profit_diff_pct = (profit_diff / lumpsum_profit * 100) if lumpsum_profit != 0 else 0.0

--- a/tests/test_pad_strategy.py
+++ b/tests/test_pad_strategy.py
@@ -1,5 +1,5 @@
 import pandas as pd
-from src.pad_strategy import backtest_pad
+from src.pad_strategy import backtest_pad, calculate_lump_sum
 
 
 def sample_price_df():
@@ -87,3 +87,17 @@ def test_net_profit_and_return():
 
     # Calculated final return should be correct
     assert abs(expected_return - (final_value / total_deposit - 1)) < 1e-8
+
+
+def test_lump_sum_calculation():
+    df = sample_price_df()
+    result = backtest_pad(df)
+
+    shares, profit = calculate_lump_sum(result)
+    total_deposit = result["TotalDeposit"].iloc[-1]
+
+    expected_shares = total_deposit / result["Price"].iloc[0]
+    expected_profit = expected_shares * result["Price"].iloc[-1] - total_deposit
+
+    assert abs(shares - expected_shares) < 1e-8
+    assert abs(profit - expected_profit) < 1e-8


### PR DESCRIPTION
## Summary
- calculate lump sum with `Price` column rather than missing `Close`
- expose `calculate_lump_sum` utility
- test lump sum calculations

## Testing
- `pip install -r requirements.txt` *(fails: No route to host)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*