### PR TITLE
Add annual return metrics and results files

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ triggers a change in deposits (both default to `20`). `--inc-pad` and
 are met (defaults `1.2` and `0.8`).
 Results can be logged to a directory using `--log <dir>`. The file is named
 using the provided arguments so multiple runs can be stored side by side.
+Summary metrics including annual returns are also written to the `results`
+directory unless `--no-results` is supplied.
 
 This prints the month‑by‑month history. At the end it prints the final
 portfolio value, the total amount deposited, the net profit and the final

--- a/tests/test_pad_strategy.py
+++ b/tests/test_pad_strategy.py
@@ -1,5 +1,9 @@
 import pandas as pd
-from src.pad_strategy import backtest_pad, calculate_lump_sum
+from src.pad_strategy import (
+    backtest_pad,
+    calculate_lump_sum,
+    calculate_annual_return,
+)
 
 
 def sample_price_df():
@@ -101,3 +105,19 @@ def test_lump_sum_calculation():
 
     assert abs(shares - expected_shares) < 1e-8
     assert abs(profit - expected_profit) < 1e-8
+
+
+def test_calculate_annual_return():
+    df = sample_price_df()
+    result = backtest_pad(df)
+
+    final_value = result["PortfolioValue"].iloc[-1]
+    total_deposit = result["TotalDeposit"].iloc[-1]
+    duration_days = (pd.to_datetime(result["Date"].iloc[-1]) - pd.to_datetime(result["Date"].iloc[0])).days
+
+    ann = calculate_annual_return(final_value, total_deposit, duration_days)
+    expected_ratio = final_value / total_deposit
+    years = duration_days / 365.0
+    expected_ann = expected_ratio ** (1 / years) - 1
+
+    assert abs(ann - expected_ann) < 1e-8


### PR DESCRIPTION
## Summary
- add `calculate_annual_return` utility
- write PAD vs lump sum annual returns
- save summary metrics in a `results` directory by default
- document new results behaviour
- test the new annual return function

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*