### PR TITLE
Improve setup docs and format values

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # AlgoTrader2
 
 This project demonstrates a simple back‑test of a **Percentage Allocation DCA (PAD)**
-strategy applied to stocks or ETFs. Each month an investor contributes `$100` by
-default. If the price drops by `20%` or more relative to the previous month, the
-monthly contribution increases by `20%` (`$120`). When the price rises by
-`20%` or more, the contribution is reduced by `20%` (`$80`).
+strategy applied to stocks or ETFs. Each month an investor contributes `$100.00` by
+default. If the price drops by `20.00%` or more relative to the previous month, the
+monthly contribution increases by `20.00%` (`$120.00`). When the price rises by
+`20.00%` or more, the contribution is reduced by `20.00%` (`$80.00`).
 
 The repository includes:
 
@@ -13,6 +13,23 @@ The repository includes:
   download historical prices automatically using `yfinance`. Prices are
   aggregated to month end so the PAD logic runs on monthly data.
 - `tests/` – unit tests validating the strategy.
+
+## Development Setup
+
+1. **Git** – Install Git from the [official site](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git). After installing, configure your name and email:
+
+   ```bash
+   git config --global user.name "Your Name"
+   git config --global user.email "you@example.com"
+   ```
+
+2. **Python** – Download Python from [python.org](https://www.python.org/downloads/). Verify the installation with:
+
+   ```bash
+   python --version
+   ```
+
+3. **VS Code** – Install Visual Studio Code from [code.visualstudio.com](https://code.visualstudio.com/) and add the Python extension for development.
 
 ## Running the back‑test
 
@@ -33,9 +50,9 @@ python src/pad_strategy.py --ticker AAPL
 
 Deposit adjustments are controlled with separate thresholds and multipliers.
 `--inc-thresh` and `--dec-thresh` specify the percentage drop or rise that
-triggers a change in deposits (both default to `20`). `--inc-pad` and
-`--dec-pad` are multipliers applied to the base deposit when those thresholds
-are met (defaults `1.2` and `0.8`).
+triggers a change in deposits (both default to `20`, which represents
+`20.00%`). `--inc-pad` and `--dec-pad` are multipliers applied to the base
+deposit when those thresholds are met (defaults `1.2` and `0.8`).
 Results can be logged to a directory using `--log <dir>`. The file is named
 using the provided arguments so multiple runs can be stored side by side.
 Summary metrics including annual returns are also written to the `results`
@@ -45,8 +62,9 @@ This prints the month‑by‑month history. At the end it prints the final
 portfolio value, the total amount deposited, the net profit and the final
 total return as a percentage.
 
-You can adjust these settings from the command line. For example, to use a 10%
-increase threshold, a 15% decrease threshold and a $150 base deposit:
+You can adjust these settings from the command line. For example, to use a
+`10.00%` increase threshold, a `15.00%` decrease threshold and a `$150.00` base
+deposit:
 
 ```bash
 python src/pad_strategy.py --base 150 --inc-thresh 10 --dec-thresh 15


### PR DESCRIPTION
## Summary
- explain how to install git, Python and VS Code
- add commands for configuring git
- clarify that inc/dec thresholds default to 20% and update example formatting
- format all percentages and cash values per repo guidelines

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for pandas)*